### PR TITLE
Feature #44

### DIFF
--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -1,0 +1,60 @@
+import { subscribeState } from '../../../controller';
+import { storeKeys } from '../../../utils/constant';
+
+export class CalendarBody {
+  constructor($target) {
+    this.$target = $target;
+    this.$body = document.createElement('table');
+    this.$body.className = 'calendar-body';
+
+    this.unsubscribeDate = subscribeState({
+      key: storeKeys.CURRENT_DATE,
+      callback: () => this.render(),
+    });
+
+    this.$target.appendChild(this.$body);
+    this.init();
+    this.render();
+  }
+
+  init() {}
+
+  render() {
+    this.$body.innerHTML = `
+        <tr>
+            <td class='today'>
+            <div class='calendar-amount'>
+                <div class='calendar-amount-income'>130,000</div>
+                <div class='calendar-amount-cost'>20,000</div>
+                <div class='calendar-amount-total'>110,000</div>
+            </div>
+            <div class='calendar-date'>1</div>
+            </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+      `;
+  }
+}

--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -45,8 +45,8 @@ export class CalendarBody {
 
           data.date = date;
           if (income || cost) {
-            if (income) data.income = income;
-            if (cost) data.cost = cost;
+          if (income) data.income = income;
+          if (cost) data.cost = cost;
             data.total = (income ?? 0) - (cost ?? 0);
           }
         }

--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -7,8 +7,8 @@ export class CalendarBody {
     this.$body = document.createElement('table');
     this.$body.className = 'calendar-body';
 
-    this.unsubscribeDate = subscribeState({
-      key: storeKeys.CURRENT_DATE,
+    this.unsubscribeHistory = subscribeState({
+      key: storeKeys.CURRENT_HISTORY,
       callback: () => this.render(),
     });
 

--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -1,5 +1,10 @@
-import { subscribeState } from '../../../controller';
-import { storeKeys } from '../../../utils/constant';
+import {
+  getIncomeAndCostSumOfDate,
+  getState,
+  subscribeState,
+} from '../../../controller';
+import { storeKeys, WEEK_LENGTH } from '../../../utils/constant';
+import { getStartAndEndDate } from '../../../utils/date';
 
 export class CalendarBody {
   constructor($target) {
@@ -54,41 +59,45 @@ export class CalendarBody {
   generateRow() {}
 
   render() {
+    const dataTable = this.makeDataTable();
+
     this.$body.innerHTML = `
-        <tr>
-            <td class='today'>
-            <div class='calendar-amount'>
-                <div class='calendar-amount-income'>130,000</div>
-                <div class='calendar-amount-cost'>20,000</div>
-                <div class='calendar-amount-total'>110,000</div>
-            </div>
-            <div class='calendar-date'>1</div>
-            </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
+        ${dataTable
+          .map(
+            (row) =>
+              `<tr>
+              ${row
+                .map(
+                  (column) =>
+                    `<td>
+                    <div class='calendar-amount'>
+                      ${
+                        column.income
+                          ? `<div class='calendar-amount-income'>${column.income}</div>`
+                          : ''
+                      }
+                      ${
+                        column.cost
+                          ? `<div class='calendar-amount-cost'>-${column.cost}</div>`
+                          : ''
+                      }
+                      ${
+                        column.total
+                          ? `<div class='calendar-amount-total'>${column.total}</div>`
+                          : ''
+                      }
+                    </div>
+                    ${
+                      column.date
+                        ? `<div class='calendar-date'>${column.date}</div>`
+                        : ''
+                    }
+                  </td>`,
+                )
+                .join('')}
+            </tr>`,
+          )
+          .join('')}
       `;
   }
 }

--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -19,6 +19,40 @@ export class CalendarBody {
 
   init() {}
 
+  makeDataTable() {
+    const { year, month } = getState({ key: storeKeys.CURRENT_DATE });
+    const { startDate, endDate } = getStartAndEndDate({ year, month });
+    const startDay = new Date(year, month - 1, startDate).getDay();
+    const trLength = Math.ceil((endDate + startDay) / WEEK_LENGTH);
+    const dataTable = new Array(trLength).fill(0).map(() =>
+      new Array(WEEK_LENGTH).fill(0).map(() => {
+        return {};
+      }),
+    );
+
+    for (let i = 0; i < trLength; i++) {
+      for (let j = 0; j < WEEK_LENGTH; j++) {
+        const date = i * WEEK_LENGTH + j - (startDay - 1);
+
+        if (date >= startDate && date <= endDate) {
+          const data = dataTable[i][j];
+          const { income, cost } = getIncomeAndCostSumOfDate(date);
+
+          data.date = date;
+          if (income || cost) {
+            if (income) data.income = income;
+            if (cost) data.cost = cost;
+            data.total = (income ?? 0) - (cost ?? 0);
+          }
+        }
+      }
+    }
+
+    return dataTable;
+  }
+
+  generateRow() {}
+
   render() {
     this.$body.innerHTML = `
         <tr>

--- a/client/src/component/Calendar/Calendar.js
+++ b/client/src/component/Calendar/Calendar.js
@@ -1,4 +1,6 @@
 import './Calendar.scss';
+import { CalendarBody } from './Body/CalendarBody';
+import { CalendarHeader } from './Header/CalenderHeader';
 
 export class Calendar {
   constructor($target) {
@@ -14,52 +16,7 @@ export class Calendar {
   init() {}
 
   render() {
-    this.$calendar.innerHTML = `
-        <div class='calendar-header'>
-            <div class='calendar-header-day sunday'>일</div>
-            <div class='calendar-header-day'>월</div>
-            <div class='calendar-header-day'>화</div>
-            <div class='calendar-header-day'>수</div>
-            <div class='calendar-header-day'>목</div>
-            <div class='calendar-header-day'>금</div>
-            <div class='calendar-header-day saturday'>토</div>
-        </div>
-        <table class='calendar-body'>
-            <tr>
-                <td class='today'>
-                  <div class='calendar-amount'>
-                    <div class='calendar-amount-income'>130,000</div>
-                    <div class='calendar-amount-cost'>20,000</div>
-                    <div class='calendar-amount-total'>110,000</div>
-                  </div>
-                  <div class='calendar-date'>1</div>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
-        </table>
-    `;
+    new CalendarHeader(this.$calendar);
+    new CalendarBody(this.$calendar);
   }
 }

--- a/client/src/component/Calendar/Calendar.js
+++ b/client/src/component/Calendar/Calendar.js
@@ -4,7 +4,7 @@ export class Calendar {
   constructor($target) {
     this.$target = $target;
     this.$calendar = document.createElement('main');
-    this.$calendar.className = 'calendar-view';
+    this.$calendar.className = 'calendar';
 
     this.$target.appendChild(this.$calendar);
     this.init();

--- a/client/src/component/Calendar/Calendar.scss
+++ b/client/src/component/Calendar/Calendar.scss
@@ -1,6 +1,6 @@
 @import '../../style/common.scss';
 
-.calendar-view {
+.calendar {
   .calendar-header {
     display: flex;
     justify-content: space-around;

--- a/client/src/component/Calendar/Header/CalenderHeader.js
+++ b/client/src/component/Calendar/Header/CalenderHeader.js
@@ -1,0 +1,25 @@
+export class CalendarHeader {
+  constructor($target) {
+    this.$target = $target;
+    this.$header = document.createElement('div');
+    this.$header.className = 'calendar-header';
+
+    this.$target.appendChild(this.$header);
+    this.init();
+    this.render();
+  }
+
+  init() {}
+
+  render() {
+    this.$header.innerHTML = `
+        <div class='calendar-header-day sunday'>일</div>
+        <div class='calendar-header-day'>월</div>
+        <div class='calendar-header-day'>화</div>
+        <div class='calendar-header-day'>수</div>
+        <div class='calendar-header-day'>목</div>
+        <div class='calendar-header-day'>금</div>
+        <div class='calendar-header-day saturday'>토</div>
+      `;
+  }
+}

--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -139,9 +139,10 @@ export const getIncomeAndCostSumOfDate = (date) => {
   let income = 0;
   let cost = 0;
 
-  const data = history.filter(({ date: d }) => d === date)[0]?.data ?? [];
+  const historyOfDate =
+    history.filter(({ date: d }) => d === date)[0]?.data ?? [];
 
-  data.forEach(({ isIncome, amount }) => {
+  historyOfDate.forEach(({ isIncome, amount }) => {
     if (isIncome) income += amount;
     else cost += amount;
   });

--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -133,6 +133,25 @@ export const getPaymentLength = () => {
   return history.reduce((p, { datas }) => p + datas.length, 0);
 };
 
+export const getIncomeAndCostSumOfDate = (date) => {
+  const history = getState({ key: storeKeys.CURRENT_HISTORY });
+
+  let income = 0;
+  let cost = 0;
+
+  const data = history.filter(({ date: d }) => d === date)[0]?.data ?? [];
+
+  data.forEach(({ isIncome, amount }) => {
+    if (isIncome) income += amount;
+    else cost += amount;
+  });
+
+  return {
+    income: income ? income : null,
+    cost: cost ? cost : null,
+  };
+};
+
 /* 결제 방법 관련 */
 export const updatePayment = async () => {
   const payment = await getMockPayment();

--- a/client/src/utils/constant.js
+++ b/client/src/utils/constant.js
@@ -1,10 +1,12 @@
 export const storeKeys = {
-    CURRENT_DATE: 'date',
-    CURRENT_MONTH: 'month',
-    CURRENT_YEAR: 'year',
-    CURRENT_HISTORY: 'history',
-    LAST_SIX_HISTORY: 'lastSixMonthHistory',
-    CATEGORY: 'category',
-    PAYMENT: 'payment',
-    SELECTED_HISTORY: 'selectedHistory',
-}
+  CURRENT_DATE: 'date',
+  CURRENT_MONTH: 'month',
+  CURRENT_YEAR: 'year',
+  CURRENT_HISTORY: 'history',
+  LAST_SIX_HISTORY: 'lastSixMonthHistory',
+  CATEGORY: 'category',
+  PAYMENT: 'payment',
+  SELECTED_HISTORY: 'selectedHistory',
+};
+
+export const WEEK_LENGTH = 7;

--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -21,6 +21,16 @@ export function getTodayString() {
   return `${year}-${month}-${day}`;
 }
 
+export function getStartAndEndDate({ year, month }) {
+  const startDate = new Date(year, month - 1, 1).getDate();
+  const endDate = new Date(year, month, 0).getDate();
+
+  return {
+    startDate,
+    endDate,
+  };
+}
+
 export function getDay(year, month, date) {
   const day = {
     1: '월',


### PR DESCRIPTION
<!-- 중요한 내용, 추가적인 기술, 구현 방법 등 -->

## 세부사항
- 캘린더 구현.

## 예상 소요시간 / 실제 소요시간
4시간 / 3시간 30분

## 참고 사항
요일을 나타내는 헤더와 실제 내용을 렌더링하는 바디 부분으로 나누었습니다.
바디 부분만 CURRENT_HISTORY에 렌더링을 의존합니다. 기존에는 date와 history 둘 다 의존했는데,
date가 변하면 history로 갱신되니 굳이 두 번 렌더링할 필요 없을 것 같아서 date는 구독하지 않았습니다.
목업데이터는 datas로 데이터를 주는 반면 서버는 data로 서버쪽에 맞춰놨습니다.

## 관련 이슈
- #44 