### PR TITLE
라우팅 구현

### DIFF
--- a/client/src/component/Calendar/Body/CalendarBody.js
+++ b/client/src/component/Calendar/Body/CalendarBody.js
@@ -44,11 +44,9 @@ export class CalendarBody {
           const { income, cost } = getIncomeAndCostSumOfDate(date);
 
           data.date = date;
-          if (income || cost) {
           if (income) data.income = income;
           if (cost) data.cost = cost;
-            data.total = (income ?? 0) - (cost ?? 0);
-          }
+          if (income || cost) data.total = (income ?? 0) - (cost ?? 0);
         }
       }
     }

--- a/client/src/component/Error/Error.js
+++ b/client/src/component/Error/Error.js
@@ -1,0 +1,37 @@
+import './Error.scss';
+import { Router } from '../../router/Router';
+
+export class Error {
+  constructor($target, code, message) {
+    this.$target = $target;
+    this.code = code;
+    this.message = message;
+    this.$error = document.createElement('div');
+    this.$error.className = 'error';
+
+    this.router = Router.getInstance();
+
+    this.$target.appendChild(this.$error);
+    this.init();
+    this.render();
+  }
+
+  init() {
+    this.$error.addEventListener('click', this.routing.bind(this));
+  }
+
+  routing(e) {
+    const $button = e.target.closest('button');
+    if (!$button) return;
+
+    this.router.push('/');
+  }
+
+  render() {
+    this.$error.innerHTML = `
+        <div class='code'>${this.code}</div>
+        <div class='message'>${this.message}</div>
+        <button class='escape'>메인 페이지로</button>
+    `;
+  }
+}

--- a/client/src/component/Error/Error.scss
+++ b/client/src/component/Error/Error.scss
@@ -1,0 +1,20 @@
+@import '../../style/common.scss';
+
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+
+  .code {
+    @include display-large-text;
+  }
+
+  .message {
+    @include body-regular-text;
+  }
+
+  .escape {
+    margin-top: 40px;
+  }
+}

--- a/client/src/component/Header/Header.js
+++ b/client/src/component/Header/Header.js
@@ -20,7 +20,6 @@ export class Header {
   routing(e) {
     const $button = e.target.closest('button');
     if (!$button) return;
-    debugger;
     if ($button.classList.contains('history-button')) this.router.push('/');
     if ($button.classList.contains('calendar-button'))
       this.router.push('/calendar');

--- a/client/src/component/Header/Header.js
+++ b/client/src/component/Header/Header.js
@@ -1,17 +1,30 @@
 import './Header.scss';
 import DaySelector from './DaySelector/DaySelector';
+import { Router } from '../../router/Router';
 
 export class Header {
   constructor($target) {
     this.$target = $target;
     this.$header = document.createElement('header');
+    this.router = Router.getInstance();
 
     this.$target.appendChild(this.$header);
     this.init();
     this.render();
   }
 
-  init() {}
+  init() {
+    this.$header.addEventListener('click', this.routing.bind(this));
+  }
+
+  routing(e) {
+    const $button = e.target.closest('button');
+    if (!$button) return;
+    debugger;
+    if ($button.classList.contains('history-button')) this.router.push('/');
+    if ($button.classList.contains('calendar-button'))
+      this.router.push('/calendar');
+  }
 
   render() {
     this.$header.innerHTML = `

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -7,6 +7,7 @@ import { updateCategory, updateHistories, updatePayment } from './controller';
 import { storeKeys } from './utils/constant';
 import { CalendarView } from './view/CalendarView';
 import { Router } from './router/Router';
+import { NotFoundView } from './view/NotFoundView';
 
 const initStore = () => {
   addState({

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,10 +5,10 @@ import { HistoryView } from './view/HistoryView';
 import { addState } from './store';
 import { updateCategory, updateHistories, updatePayment } from './controller';
 import { storeKeys } from './utils/constant';
+import { CalendarView } from './view/CalendarView';
+import { Router } from './router/Router';
 
-// initStore
 const initStore = () => {
-  // state 선언
   addState({
     key: storeKeys.CURRENT_DATE,
     initState: {
@@ -27,5 +27,14 @@ const initStore = () => {
   updatePayment();
 };
 
+const initRouter = () => {
+  Router.init(document.getElementById('root'), {
+    '/': HistoryView,
+    '/history': HistoryView,
+    '/calendar': CalendarView,
+    '/404': NotFoundView,
+  });
+};
+
 initStore();
-new HistoryView(document.getElementById('root'));
+initRouter();

--- a/client/src/router/Router.js
+++ b/client/src/router/Router.js
@@ -26,13 +26,13 @@ export const Router = (function () {
       new Component(target);
     }
 
-    return { push };
+    return { push, route };
   }
 
   return {
     init: ($target, mapper) => {
       if (!instance) instance = setInstance($target, mapper);
-      instance.push('/');
+      instance.route();
     },
 
     getInstance: () => {

--- a/client/src/router/Router.js
+++ b/client/src/router/Router.js
@@ -26,13 +26,13 @@ export const Router = (function () {
       new Component(target);
     }
 
-    route();
     return { push };
   }
 
   return {
     init: ($target, mapper) => {
       if (!instance) instance = setInstance($target, mapper);
+      instance.push('/');
     },
 
     getInstance: () => {

--- a/client/src/view/NotFoundView.js
+++ b/client/src/view/NotFoundView.js
@@ -1,0 +1,15 @@
+import { Error } from '../component/Error/Error';
+import { Header } from '../component/Header/Header';
+
+export class NotFoundView {
+  constructor($target) {
+    this.$target = $target;
+
+    new Header(this.$target);
+    new Error(this.$target, 404, '페이지를 찾을 수 없습니다.');
+  }
+
+  init() {}
+
+  render() {}
+}


### PR DESCRIPTION
<!-- 중요한 내용, 추가적인 기술, 구현 방법 등 -->

## 세부사항
- '/', '/history' 경로를 historyView로 라우팅
- '/calendar' 경로를 calendarView로 라우팅
- 이 외의 경로를 간단한 404 페이지로 라우팅
- 404 페이지는 메인페이지로 이동할 수 있는 경로를 포함함

## 예상 소요시간 / 실제 소요시간
2시간 / 1시간

## 참고 사항
chart 페이지가 미완성으로 라우팅되지 않았습니다.
서버와 함께 동작해야 정상적으로 없는 경로에 대해 404 페이지로 라우팅됩니다.
에러 메세지 컴포넌트는 코드와 message를 입력받아 커스텀 할 수 있는 형태로 만들어져 있습니다.

## 관련 이슈
- #46 