### PR TITLE
History 페이지 버그 수정

### DIFF
--- a/client/src/api/history.js
+++ b/client/src/api/history.js
@@ -12,8 +12,6 @@ export const getAllHistory = async (year, month) => {
     console.log(response.message);
   }
 
-  console.log(response);
-
   return response;
 };
 
@@ -42,8 +40,6 @@ export const postHistory = async (history) => {
     requestURL: URL_PRIFIX,
     body: history,
   });
-
-  console.log('왜안와');
 
   if (response instanceof Error) {
     console.log(response.message);

--- a/client/src/component/Calendar/Calendar.scss
+++ b/client/src/component/Calendar/Calendar.scss
@@ -1,6 +1,8 @@
 @import '../../style/common.scss';
 
 .calendar {
+  margin-top: 40px;
+
   .calendar-header {
     display: flex;
     justify-content: space-around;

--- a/client/src/component/Header/DaySelector/DaySelector.js
+++ b/client/src/component/Header/DaySelector/DaySelector.js
@@ -31,6 +31,9 @@ export default class DaySelector {
   }
 
   onClickLeftArrow(e) {
+    const $leftArrow = e.target.closest('.left-arrow');
+    if (!$leftArrow) return;
+
     decreaseMonth();
   }
 

--- a/client/src/component/History/History.scss
+++ b/client/src/component/History/History.scss
@@ -76,6 +76,37 @@
           vertical-align: middle;
           text-align: center;
           padding: 0 5px;
+
+          .salary {
+            background-color: #b9d58c;
+          }
+          .allowance {
+            background-color: #e6d267;
+          }
+          .etc-income {
+            background-color: #e2b765;
+          }
+          .food {
+            background-color: #4a6cc3;
+          }
+          .life {
+            background-color: #4ca1de;
+          }
+          .shopping {
+            background-color: #94d3cc;
+          }
+          .traffic {
+            background-color: #4cb8b8;
+          }
+          .medical {
+            background-color: #6ed5eb;
+          }
+          .culture {
+            background-color: #d092e2;
+          }
+          .etc-cost {
+            background-color: #817dce;
+          }
         }
 
         .category {

--- a/client/src/component/History/History.scss
+++ b/client/src/component/History/History.scss
@@ -1,8 +1,6 @@
 @import '../../style/common.scss';
 
 .history-view {
-  margin-top: 40px;
-
   .title {
     display: flex;
     justify-content: space-between;

--- a/client/src/component/History/List/List.js
+++ b/client/src/component/History/List/List.js
@@ -5,7 +5,7 @@ import {
   getCostSum,
 } from '../../../controller';
 import { subscribeState } from '../../../controller';
-import { CategoryColor, storeKeys } from '../../../utils/constant';
+import { categoryClassName, storeKeys } from '../../../utils/constant';
 import { getDay } from '../../../utils/date';
 
 export class List {
@@ -80,9 +80,9 @@ export class List {
       ${data
         .map(
           (value) => `<tr data-id=${value.id}>
-          <td class='category'><span style='background-color: ${
-            CategoryColor[value.categoryId]
-          }'>${
+          <td class='category'><span class=${
+            categoryClassName[value.categoryId]
+          }>${
             category.filter((c) => c.id === value.categoryId)[0]?.content ?? ''
           }</span></td>
           <td class='content'>${value.content}</td>

--- a/client/src/component/History/List/List.js
+++ b/client/src/component/History/List/List.js
@@ -21,6 +21,13 @@ export class List {
       },
     });
 
+    this.unsubscribePayment = subscribeState({
+      key: storeKeys.PAYMENT,
+      callback: () => {
+        this.render();
+      },
+    });
+
     this.$target.appendChild(this.$list);
     this.init();
     this.render();

--- a/client/src/component/History/List/List.js
+++ b/client/src/component/History/List/List.js
@@ -34,16 +34,24 @@ export class List {
   }
 
   init() {
-    this.$list.addEventListener('click', (e) => {
-      const $tr = e.target.closest('tr');
-      if (!$tr) return;
+    this.$list.addEventListener('click', this.selectHistoryItem);
+  }
 
-      // .active 클래스 붙이기
+  selectHistoryItem(e) {
+    const $tr = e.target.closest('tr');
+    if (!$tr) return;
 
-      // set selected history
+    if ($tr.classList.contains('active')) {
+      changeSelectedHistory({});
+      $tr.classList.remove('active');
+    } else {
       const trId = Number($tr.dataset.id);
       changeSelectedHistory({ id: trId });
-    });
+      document
+        .querySelectorAll('tr')
+        .forEach((e) => e.classList.remove('active'));
+      $tr.classList.add('active');
+    }
   }
 
   render() {

--- a/client/src/component/History/List/List.js
+++ b/client/src/component/History/List/List.js
@@ -5,7 +5,7 @@ import {
   getCostSum,
 } from '../../../controller';
 import { subscribeState } from '../../../controller';
-import { storeKeys } from '../../../utils/constant';
+import { CategoryColor, storeKeys } from '../../../utils/constant';
 import { getDay } from '../../../utils/date';
 
 export class List {
@@ -73,7 +73,7 @@ export class List {
         .map(
           (value) => `<tr data-id=${value.id}>
           <td class='category'><span style='background-color: ${
-            category.filter((c) => c.id === value.categoryId)[0]?.color
+            CategoryColor[value.categoryId]
           }'>${
             category.filter((c) => c.id === value.categoryId)[0]?.content ?? ''
           }</span></td>

--- a/client/src/component/InputForm/AmountInput/AmountInput.js
+++ b/client/src/component/InputForm/AmountInput/AmountInput.js
@@ -56,9 +56,9 @@ export class AmountInput {
     <label for="type">금액</label>
     <div class="field">
         <input type="checkbox" name="isIncome" id='isIncome' ${
-          history.isIncome !== false ? 'checked' : ''
-        }></input>
-        <label for='isIncome'></label>
+          history.isIncome === 1 ? 'checked' : ''
+        }>
+        <label for='isIncome' id='isIncomeLabel'></label>
         <input type="text" name="amount" placeholder="입력하세요" autocomplete="off" value="${
           history.amount ?? ''
         }"/>원

--- a/client/src/component/InputForm/AmountInput/AmountInput.js
+++ b/client/src/component/InputForm/AmountInput/AmountInput.js
@@ -33,9 +33,8 @@ export class AmountInput {
 
     const $dropdown = document.querySelector('.dropdown');
 
-    $dropdown.innerHTML = categoryStore
-      .get()
-      .filter(({ isIncome }) => isIncome === $isIncome.checked)
+    $dropdown.innerHTML = getState({ key: storeKeys.CATEGORY })
+      .filter(({ isIncome }) => Boolean(isIncome) === $isIncome.checked)
       .map(
         ({ id, content }) => `
             <li data-id=${id}>${content}</li>

--- a/client/src/component/InputForm/AmountInput/AmountInput.js
+++ b/client/src/component/InputForm/AmountInput/AmountInput.js
@@ -45,6 +45,7 @@ export class AmountInput {
   }
 
   onClickIsIncome(event) {
+    event.stopPropagation();
     const $isIncome = event.target.closest('#isIncome');
     if (!$isIncome) return;
     this.onChangeIsIncome();

--- a/client/src/component/InputForm/CategoryInput/CategoryInput.js
+++ b/client/src/component/InputForm/CategoryInput/CategoryInput.js
@@ -86,7 +86,7 @@ export default class CategoryInput {
         ({ isIncome }) =>
           history.isIncome !== undefined
             ? history.isIncome === isIncome
-            : isIncome === 1, // category 초기값은 수입(+)에 대한 것
+          : isIncome === 0,
       )
       .map(
         ({ id, content }) => `

--- a/client/src/component/InputForm/CategoryInput/CategoryInput.js
+++ b/client/src/component/InputForm/CategoryInput/CategoryInput.js
@@ -74,7 +74,7 @@ export default class CategoryInput {
         <input type="text" name="type" placeholder="선택하세요" value="${
           category.filter(({ id }) => id === history.categoryId)[0]?.content ??
           ''
-        }" date-id="${history.categoryId ?? ''}" readonly/>
+        }" data-id="${history.categoryId ?? ''}" readonly/>
         <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M4 6.5L8 10.5L12 6.5" stroke="#8D9393" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>

--- a/client/src/component/InputForm/DateInput/DateInput.js
+++ b/client/src/component/InputForm/DateInput/DateInput.js
@@ -18,7 +18,9 @@ export class DateInput {
     this.render();
   }
 
-  init() {}
+  init() {
+    this.$dateInput.addEventListener('click', (e) => e.stopPropagation());
+  }
 
   render() {
     const { year, month, date } = getState({ key: storeKeys.SELECTED_HISTORY });

--- a/client/src/component/InputForm/InputForm.js
+++ b/client/src/component/InputForm/InputForm.js
@@ -43,8 +43,6 @@ export class InputForm {
     const paymentId = Number($payment.dataset.id);
     const amount = Number($amount.value);
 
-    // const currentYear = getState({ key: storeKeys.CURRENT_YEAR });
-    // const currentMonth = getState({ key: storeKeys.CURRENT_MONTH });
     const history = {
       currentYear: 2022,
       currentMonth: 5,

--- a/client/src/component/InputForm/InputForm.js
+++ b/client/src/component/InputForm/InputForm.js
@@ -34,7 +34,6 @@ export class InputForm {
     const $category = document.querySelector('input[name="type"]');
     const $content = document.querySelector('input[name="title"]');
     const $payment = document.querySelector('input[name="payment"]');
-    const $isIncome = document.querySelector('input[name="isIncome"]');
     const $amount = document.querySelector('input[name="amount"]');
 
     const [year, month, date] = $date.value.split('-').map((d) => Number(d));

--- a/client/src/component/InputForm/InputForm.js
+++ b/client/src/component/InputForm/InputForm.js
@@ -36,6 +36,7 @@ export class InputForm {
     const $payment = document.querySelector('input[name="payment"]');
     const $amount = document.querySelector('input[name="amount"]');
 
+    const currentDate = getState({ key: storeKeys.CURRENT_DATE });
     const [year, month, date] = $date.value.split('-').map((d) => Number(d));
     const categoryId = Number($category.dataset.id);
     const content = $content.value;
@@ -43,12 +44,12 @@ export class InputForm {
     const amount = Number($amount.value);
 
     const history = {
-      currentYear: 2022,
-      currentMonth: 5,
+      currentYear: currentDate.year,
+      currentMonth: currentDate.month,
       year,
       month,
       date,
-      categoryId: 1,
+      categoryId,
       content,
       paymentId,
       amount,

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -9,6 +9,6 @@ body {
 
 main {
   width: 850px;
-  margin: 40px auto;
+  margin: 0px auto;
   accent-color: $color-primary;
 }

--- a/client/src/utils/constant.js
+++ b/client/src/utils/constant.js
@@ -9,17 +9,17 @@ export const storeKeys = {
   SELECTED_HISTORY: 'selectedHistory',
 };
 
-export const CategoryColor = {
-  1: '#B9D58C',
-  2: '#E6D267',
-  3: '#E2B765',
-  4: '#4A6CC3',
-  5: '#4CA1DE',
-  6: '#94D3CC',
-  7: '#4CB8B8',
-  8: '#6ED5EB',
-  9: '#D092E2',
-  10: '#817DCE',
+export const categoryClassName = {
+  1: 'salary',
+  2: 'allowance',
+  3: 'etc-income',
+  4: 'food',
+  5: 'life',
+  6: 'shopping',
+  7: 'traffic',
+  8: 'medical',
+  9: 'culture',
+  10: 'etc-cost',
 };
 
 export const WEEK_LENGTH = 7;

--- a/client/src/utils/constant.js
+++ b/client/src/utils/constant.js
@@ -9,4 +9,17 @@ export const storeKeys = {
   SELECTED_HISTORY: 'selectedHistory',
 };
 
+export const CategoryColor = {
+  1: '#B9D58C',
+  2: '#E6D267',
+  3: '#E2B765',
+  4: '#4A6CC3',
+  5: '#4CA1DE',
+  6: '#94D3CC',
+  7: '#4CB8B8',
+  8: '#6ED5EB',
+  9: '#D092E2',
+  10: '#817DCE',
+};
+
 export const WEEK_LENGTH = 7;


### PR DESCRIPTION
<!-- 중요한 내용, 추가적인 기술, 구현 방법 등 -->

## 세부사항
- isIncome 라벨 클릭 시, check box 미동작
  이벤트 전파 과정 중 preventDefault() 선언되어있어 발생하는 듯 합니다.
  stopPropagation 사용하여 해결했습니다.

- 내역 등록/수정 후 히스토리 컴포넌트가 렌더링 �되지 않음
  api 전달 파라미터 수정했습니다.

- 금액 input 클릭 시 분류값이 초기화 됨
- 결제수단 추가/삭제버튼 시 모달 창 띄우지않고 에러 발생
  재현 불가. 다시 발생하면 알려주세요.

이 외에 카테고리 미출력 오류, 선택된 내역 강조 처리의 작업을 했습니다.

## 예상 소요시간 / 실제 소요시간
1시간 / 2시간

## 참고 사항
post 또는 put 제출 후 input form이 비워지지 않는 현상이 있습니다.

## 관련 이슈
- #49 